### PR TITLE
Update SLIME installation instructions to use quicklisp-slime-helper

### DIFF
--- a/docs/tutorial/using-cl-implementation.md
+++ b/docs/tutorial/using-cl-implementation.md
@@ -636,7 +636,7 @@ Key features of SLIME:
 3. **Install SLIME via Quicklisp:** Within your Lisp REPL, evaluate:
 
     ```lisp
-    (ql:quickload "slime")
+    (ql:quickload "quicklisp-slime-helper")
     ```
 
 4. **Configure Emacs:** Add the following lines to your Emacs initialization file (e.g., `~/.emacs` or `~/.emacs.d/init.el`):


### PR DESCRIPTION
Quicklisp seems to have been updated to use this tool instead of "slime".